### PR TITLE
Added Sentry/Raven version notes to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,3 +89,14 @@ Follow the steps below, if you want to enable Sentry's email notifications:
 3. Set the email addresses that should be notified::
 
         heroku config:set ADMINS=john.matrix@example.com,jack.daniels@example.com
+
+
+Version notes
+-------------------
+
+The version of Sentry pinned in the ``requirements.txt`` file is one of the last for which Redis was not a hard dependency. Newer versions of Sentry will not work on Heroku using this configuration as Redis is required.
+
+Note that if you are sending events from raven (e.g. in Django) to an installation of Sentry provided by this repo, you will need to pin the raven version to ``5.0.0`` otherwise you will get errors about mismatched protocols.
+
+You may also need to add a ``?timeout=`` parameter to your DSN URL in Django, or messages to Sentry may time out. Values of 3 seconds and up seem to work fine.
+


### PR DESCRIPTION
Hello, just added a couple of hopefully useful notes to the README about using raven as a client (e.g. in Django). I found I had to pin raven to the same version as used in this repo in order to have messages delivered without protocol-mismatch errors. Just wanted to help out anyone who might fall foul of that if they just `pip install raven` without a specific version.

Also added a note about the DSN `timeout` parameter as I needed that too before I could communicate between Heroku apps without timeout errors.

Hope that helps! Thanks so much for the original project – very useful.